### PR TITLE
Add exception for filemaker files

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,6 +9,34 @@ class WSU_PRF_Theme {
 	 * Setup the hooks used in the theme.
 	 */
 	public function __construct() {
+
+		add_filter( 'wp_check_filetype_and_ext', array( $this, 'allow_filemaker_extensions' ), 10, 4 );
+	}
+
+	public function allow_filemaker_extensions( $types, $file, $filename, $mimes ) {
+
+		// Recognized filemaker extensions
+		$extensions = array( '.fp7', '.fp5', '.fmp12' );
+
+		// Loop through all the extensions
+		foreach ( $extensions as $extension ) {
+
+			// Check if extension is used
+			if ( false !== strpos( $filename, $extension ) ) {
+
+				// remove . from extension string
+				$ext = str_replace( '.', '', $extension );
+
+				$types['ext'] = $ext;
+
+				$types['type'] = 'application/x-filemaker';
+
+			} // End if
+
+		} // End foreach
+		
+		return $types;
+
 	}
 	
 }


### PR DESCRIPTION
Add exceptions to allow for filemaker files

## Added
- Added filter hook to functions.php for wp_check_filetype_and_ext. This intercepts the check on application type and allows for an override.
- Added method to WSU_PRF_Theme in functions.php to check for filemaker extensions and override default application type check.